### PR TITLE
Add swift-syntax version comment to Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            exact: "600.0.0"
+            exact: "600.0.0" // Must match SwiftSyntaxSugar's swift-syntax version
         ),
         .package(
             url: "https://github.com/fetch-rewards/SwiftSyntaxSugar.git",


### PR DESCRIPTION
## 📝 Summary

<!-- 
Please provide a brief summary of your changes along with any relevant context.
Include any screenshots, logs, or terminal output you think would be helpful to reviewers.
-->

- Added a comment to `Package.swift` explaining that the `swift-syntax` dependency's version must match `SwiftSyntaxSugar`'s `swift-syntax` version.

## 🛠️ Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [x] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-synchronization/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-synchronization/blob/main/CODE_OF_CONDUCT.md)