### PR TITLE
Update SwiftFormat minimum version and output version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,14 @@ jobs:
           xcode-version: latest
 
       - name: Install Brewfile dependencies
-        run: brew bundle install
+        run: |
+          brew update --quiet
+          brew bundle install
 
       - name: Run SwiftFormat in lint mode
-        run: swiftformat --lint .
+        run: |
+          swiftformat --version
+          swiftformat --lint .
 
       - name: Install package dependencies
         run: swift package resolve

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,7 @@
 --swiftversion 6.0
 
 # SwiftFormat Version
---minversion 0.55.3
+--minversion 0.56.2
 
 # Options
 


### PR DESCRIPTION
## 📝 Summary

- Updated the SwiftFormat minimum version to `0.56.2`
- Modified the CI workflow to output `swiftformat --version` before running SwiftFormat
- Modified the CI workflow to run `brew update --quiet` before installing the bundle.

Adding the version output to the CI workflow helps verify which version of SwiftFormat is being used during CI runs, aiding in debugging.

## 🛠️ Type of Change

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [ ] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [x] Updating dependencies (Swift packages, Homebrew, etc.)
- [x] CI/CD (change to automated workflows)

## 🧪 How Has This Been Tested?

I've verified SwiftFormat 0.56.2 is installed when running `brew bundle install`.

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-synchronization/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-synchronization/blob/main/CODE_OF_CONDUCT.md)
